### PR TITLE
Sssd is enabled by default in Redhat 8 to cache passwd, group, servic…

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -362,11 +362,11 @@ class nscd (
         }
         '8': {
           $service_provider_default          = undef
-          $enable_db_passwd_default          = true
-          $enable_db_group_default           = true
+          $enable_db_passwd_default          = false
+          $enable_db_group_default           = false
           $enable_db_hosts_default           = true
-          $enable_db_services_default        = true
-          $enable_db_netgroup_default        = true
+          $enable_db_services_default        = false
+          $enable_db_netgroup_default        = false
           $enable_db_audit_user_default      = false
           $enable_db_auth_attr_default       = false
           $enable_db_bootparams_default      = false

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -82,7 +82,11 @@ describe 'nscd' do
         :osfamily                  => 'RedHat',
         :operatingsystemmajrelease => '8',
         :server_user               => 'nscd',
-        :enable_db_netgroup        => true,
+        :enable_db_services        => false,
+        :enable_db_netgroup        => false,
+        :enable_db_passwd          => false,
+        :enable_db_group           => false,
+        :enable_db_hosts           => true,
       }),
     'suse10' => defaults.merge({
          :osfamily                  => 'Suse',


### PR DESCRIPTION
…es, netgroup.  Caching these also with nscd leads to unexpected results

re: https://github.com/ghoneycutt/puppet-module-nscd/pull/69

discussing the clash:
https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/system-level_authentication_guide/usingnscd-sssd

sssd on by default:
https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/considerations_in_adopting_rhel_8/index#local-users-cached-by-sssd-nsssss_considerations-in-adopting-RHEL-8